### PR TITLE
Load connection string from config and add tracing

### DIFF
--- a/ConfigImport.csproj
+++ b/ConfigImport.csproj
@@ -7,5 +7,12 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Domain/UserConfigs/GraphsConfigRepository.cs
+++ b/Domain/UserConfigs/GraphsConfigRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 using Dapper;
 using Microsoft.Data.SqlClient;
@@ -16,6 +17,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public Dictionary<string, List<short>> Load(string user)
         {
+            Trace.WriteLine($"Loading graphs configuration for user {user}");
             const string sql = "SELECT GraphUid, VariableId FROM dbo.GraphsConfig WHERE UserName = @UserName";
             using var connection = new SqlConnection(_connectionString);
             var rows = connection.Query(sql, new { UserName = user });
@@ -39,6 +41,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public void Save(string user, Dictionary<string, List<short>> data)
         {
+            Trace.WriteLine($"Saving graphs configuration for user {user}");
 
             const string deleteSql = "DELETE FROM dbo.GraphsConfig WHERE UserName = @UserName";
             const string insertSql = "INSERT INTO dbo.GraphsConfig (UserName, GraphUid, VariableId) VALUES (@UserName, @GraphUid, @VariableId)";
@@ -62,6 +65,7 @@ namespace ConfigImport.Domain.UserConfigs
             }
 
             tx.Commit();
+            Trace.WriteLine("Graphs configuration saved");
 
         }
     }

--- a/Domain/UserConfigs/ImageMappingRepository.cs
+++ b/Domain/UserConfigs/ImageMappingRepository.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-
+using System.Diagnostics;
 
 using Dapper;
 using Microsoft.Data.SqlClient;
@@ -17,6 +17,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public Dictionary<string, Dictionary<string, string>> Load(string user)
         {
+            Trace.WriteLine($"Loading image mappings for user {user}");
 
             const string sql = "SELECT FormName, ElementId, ImagePath FROM dbo.ImageMappings WHERE UserName = @UserName";
             using var connection = new SqlConnection(_connectionString);
@@ -42,6 +43,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public void Save(string user, Dictionary<string, Dictionary<string, string>> data)
         {
+            Trace.WriteLine($"Saving image mappings for user {user}");
 
             const string deleteSql = "DELETE FROM dbo.ImageMappings WHERE UserName = @UserName";
             const string insertSql = "INSERT INTO dbo.ImageMappings (UserName, FormName, ElementId, ImagePath) VALUES (@UserName, @FormName, @ElementId, @ImagePath)";
@@ -66,6 +68,7 @@ namespace ConfigImport.Domain.UserConfigs
             }
 
             tx.Commit();
+            Trace.WriteLine("Image mappings saved");
 
         }
     }

--- a/Domain/UserConfigs/TagMappingRepository.cs
+++ b/Domain/UserConfigs/TagMappingRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Dapper;
 using Microsoft.Data.SqlClient;
 
@@ -17,6 +18,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public Dictionary<string, Dictionary<string, TagMappingEntry>> Load(string user)
         {
+            Trace.WriteLine($"Loading tag mappings for user {user}");
             const string sql = "SELECT FormName, ElementId, TagValue, TagEstado FROM dbo.TagMappings WHERE UserName = @UserName";
             using var connection = new SqlConnection(_connectionString);
             var rows = connection.Query(sql, new { UserName = user });
@@ -45,6 +47,7 @@ namespace ConfigImport.Domain.UserConfigs
 
         public void Save(string user, Dictionary<string, Dictionary<string, TagMappingEntry>> data)
         {
+            Trace.WriteLine($"Saving tag mappings for user {user}");
             const string deleteSql = "DELETE FROM dbo.TagMappings WHERE UserName = @UserName";
             const string insertSql = "INSERT INTO dbo.TagMappings (UserName, FormName, ElementId, TagValue, TagEstado) VALUES (@UserName, @FormName, @ElementId, @TagValue, @TagEstado)";
 
@@ -71,6 +74,7 @@ namespace ConfigImport.Domain.UserConfigs
             }
 
             tx.Commit();
+            Trace.WriteLine("Tag mappings saved");
 
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using ConfigImport.Domain.UserConfigs;
+using Microsoft.Extensions.Configuration;
 
 namespace ConfigImport
 {
@@ -10,18 +12,32 @@ namespace ConfigImport
     {
         public static void Main(string[] args)
         {
-            if (args.Length < 2)
+            Trace.Listeners.Add(new ConsoleTraceListener());
+
+            var config = new ConfigurationBuilder()
+                .SetBasePath(AppContext.BaseDirectory)
+                .AddJsonFile("appsettings.json", optional: false)
+                .Build();
+
+            var connectionString = config.GetConnectionString("DefaultConnection");
+            if (string.IsNullOrEmpty(connectionString))
             {
-                Console.WriteLine("Usage: dotnet run --project ConfigImport -- <connectionString> <user> [configFolder]");
+                Console.WriteLine("Connection string not found in configuration.");
                 return;
             }
 
-            var connectionString = args[0];
-            var user = args[1];
-            var folder = args.Length > 2 ? args[2] : Directory.GetCurrentDirectory();
+            if (args.Length < 1)
+            {
+                Console.WriteLine("Usage: dotnet run --project ConfigImport -- <user> [configFolder]");
+                return;
+            }
 
+            var user = args[0];
+            var folder = args.Length > 1 ? args[1] : Directory.GetCurrentDirectory();
+
+            Trace.WriteLine($"Starting import for user {user} from folder {folder}");
             Import(connectionString, user, folder);
-            Console.WriteLine("Import completed.");
+            Trace.WriteLine("Import completed.");
         }
 
         private static void Import(string connectionString, string user, string folder)
@@ -33,13 +49,19 @@ namespace ConfigImport
             var imageFile = Path.Combine(folder, "ImageMappings.json");
             if (File.Exists(imageFile))
             {
+                Trace.WriteLine("Importing image mappings");
                 var data = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(File.ReadAllText(imageFile)) ?? new();
                 imageRepo.Save(user, data);
+            }
+            else
+            {
+                Trace.WriteLine("Image mappings file not found");
             }
 
             var tagFile = Path.Combine(folder, "Mapeos.json");
             if (File.Exists(tagFile))
             {
+                Trace.WriteLine("Importing tag mappings");
 
                 var raw = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, JsonElement>>>(File.ReadAllText(tagFile)) ?? new();
                 short ReadShort(JsonElement el) => el.ValueKind == JsonValueKind.Number
@@ -71,12 +93,21 @@ namespace ConfigImport
 
                 tagRepo.Save(user, data);
             }
+            else
+            {
+                Trace.WriteLine("Tag mappings file not found");
+            }
 
             var graphsFile = Path.Combine(folder, "GraficasMultiples.json");
             if (File.Exists(graphsFile))
             {
+                Trace.WriteLine("Importing graphs configuration");
                 var data = JsonSerializer.Deserialize<Dictionary<string, List<short>>>(File.ReadAllText(graphsFile)) ?? new();
                 graphsRepo.Save(user, data);
+            }
+            else
+            {
+                Trace.WriteLine("Graphs configuration file not found");
             }
         }
     }

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=.;Database=MyDb;User Id=myuser;Password=mypassword;"
+  }
+}


### PR DESCRIPTION
## Summary
- read database connection string from appsettings.json instead of command line
- instrument import process and repositories with Trace logging
- reference Microsoft.Extensions.Configuration packages and copy appsettings.json

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a794de18832a9502ae16b6821701